### PR TITLE
Fixing Lock Elision Semantics by Adding Lock to Read Set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+*.asm
+*.rtm
+*.seq
+*.o
+!Makefile.rtm
+!Makefile.seq

--- a/lib/rtm.h
+++ b/lib/rtm.h
@@ -39,12 +39,11 @@
         }
 #endif // OLD_RTM_MACROSES
 
-#define XBEGIN(label)   \
-     asm volatile goto(".byte 0xc7,0xf8 ; .long %l0-1f\n1:" ::: "eax","memory" : label)
-#define XEND()    asm volatile(".byte 0x0f,0x01,0xd5" ::: "memory")
+#define XBEGIN(label) asm volatile goto(".byte 0xc7,0xf8 ; .long %l0-1f\n1:" ::: "eax","memory" : label)
+#define XEND() asm volatile(".byte 0x0f,0x01,0xd5" ::: "memory")
 #define XFAIL(label) label: do { asm volatile(".byte 0x48, 0x87, 0xC9" ::: "memory"); asm volatile("" ::: "eax", "memory"); } while(0)
 #define XFAIL_STATUS(label, status) label: asm volatile("" : "=a" (status) :: "memory")
-#define XABORT(status) { asm volatile (".byte 0xc6, 0xf8, " #status :::"eax"); }
+#define XABORT(status) do { asm volatile (".byte 0xc6, 0xf8, " #status :::"eax"); } while(0)
 #define XTEST() ({ char o = 0 ;                     \
            asm volatile(".byte 0x0f,0x01,0xd6 ; setnz %0" : "+r" (o)::"memory"); \
            o; })

--- a/lib/rtm.h
+++ b/lib/rtm.h
@@ -23,6 +23,7 @@
         assert(rtm_present && "RTM is not present"); \
         }
 
+// These macros are never defined
 #ifdef OLD_RTM_MACROSES
 // Issue 'XBEGIN -6' to jump to the beginning of the Tx
 #define _xbegin() {\
@@ -38,12 +39,12 @@
         }
 #endif // OLD_RTM_MACROSES
 
-#define XABORT(status) asm volatile(".byte 0xc6,0xf8,%P0" :: "i" (status))
 #define XBEGIN(label)   \
      asm volatile goto(".byte 0xc7,0xf8 ; .long %l0-1f\n1:" ::: "eax","memory" : label)
 #define XEND()    asm volatile(".byte 0x0f,0x01,0xd5" ::: "memory")
-#define XFAIL(label) label: asm volatile("" ::: "eax", "memory")
+#define XFAIL(label) label: do { asm volatile(".byte 0x48, 0x87, 0xC9" ::: "memory"); asm volatile("" ::: "eax", "memory"); } while(0)
 #define XFAIL_STATUS(label, status) label: asm volatile("" : "=a" (status) :: "memory")
+#define XABORT(status) { asm volatile (".byte 0xc6, 0xf8, " #status :::"eax"); }
 #define XTEST() ({ char o = 0 ;                     \
            asm volatile(".byte 0x0f,0x01,0xd6 ; setnz %0" : "+r" (o)::"memory"); \
            o; })

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -84,7 +84,7 @@ static void            (*global_funcPtr)(void*) = NULL;
 static void*             global_argPtr          = NULL;
 static volatile bool_t   global_doShutdown      = FALSE;
 
-THREAD_MUTEX_T global_rtm_mutex;
+spinlock_t global_rtm_mutex; // Fall back path
 
 /* =============================================================================
  * threadWait


### PR DESCRIPTION
#1 This pull requests fixes lock elision semantics by adding the lock to the read set after transaction begins. This is necessary for RTM transactions to be notified and abort when the lock is acquired by threads running the fall back path. Otherwise, threads running on the RTM path may commit while another thread is executing in the critical section, causing the latter to read inconsistent data.

I have observed a few crashes while running the current version of lock elision on zSim. After adding the fix these crashes seem to vanish.